### PR TITLE
API v2 이메일 목록, 로그 조회 limit과 offset 입력 가드 문서화

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -123,6 +123,7 @@ paths:
           schema:
             type: integer
             format: int
+            minimum: 0
             default: 0
         - name: limit
           in: query
@@ -130,6 +131,8 @@ paths:
           schema:
             type: integer
             format: int
+            minimum: 1
+            maximum: 100
             default: 20
       responses:
         '200':
@@ -138,6 +141,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetEmailsResponse'
+        '400':
+          description: 잘못된 요청
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidRequestNotNumber:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "offset이 숫자가 아닙니다."
+                  description: "offset 또는 limit이 숫자가 아닌 경우"
+                InvalidRequestNegativeOffset:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "offset이 0 이상이어야 합니다."
+                InvalidRequestInvalidLimit:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "limit이 1 이상이어야 합니다."
+                LimitExceeded:
+                  value:
+                    code: "stberror.Errors.Data.LimitExceeded"
+                    httpStatusCode: 400
+                    message: "이메일 목록 조회는 한 번에 최대 100건까지입니다."
 
     post:
       summary: 일반 이메일 생성
@@ -353,6 +384,7 @@ paths:
           schema:
             type: integer
             minimum: 1
+            maximum: 1000
             default: 20
       responses:
         '200':
@@ -361,6 +393,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailLogsResponse'
+        '400':
+          description: 잘못된 요청
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidRequestNotNumber:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "offset이 숫자가 아닙니다."
+                  description: "offset 또는 limit이 숫자가 아닌 경우"
+                InvalidRequestNegativeOffset:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "offset이 0 이상이어야 합니다."
+                InvalidRequestInvalidLimit:
+                  value:
+                    code: "stberror.Errors.Data.InvalidRequest"
+                    httpStatusCode: 400
+                    message: "limit이 1 이상이어야 합니다."
+                LimitExceeded:
+                  value:
+                    code: "stberror.Errors.Data.LimitExceeded"
+                    httpStatusCode: 400
+                    message: "이메일 로그 조회는 한 번에 최대 1000건까지입니다."
 
   /emails/{id}/copy:
 


### PR DESCRIPTION
## 배경

API v2 이메일 엔드포인트의 입력 검증 동작이 강화되어 OpenAPI 명세에 반영한다. 클라이언트가 400 응답 사유와 limit 상한을 사전에 인지할 수 있도록 한다.

## 변경

### GET /v2/emails

- `offset`: `minimum: 0` 명시
- `limit`: `minimum: 1`, `maximum: 100` 명시
- 400 응답 정의 추가, examples 4종
  - `InvalidRequestNotNumber`: offset 또는 limit이 숫자가 아님
  - `InvalidRequestNegativeOffset`: offset이 0 미만
  - `InvalidRequestInvalidLimit`: limit이 1 미만
  - `LimitExceeded`: limit이 100 초과

### GET /v2/emails/{id}/logs

- `limit`: `maximum: 1000` 추가 (`minimum: 1`은 이전부터 있음)
- 400 응답 정의 추가, examples 4종 동일 구조 (`LimitExceeded`는 1000건 기준)

### 400 응답 컨벤션

기존 main 패턴에 맞춤.

- 스키마는 `$ref: '#/components/schemas/ErrorResponse'`
- examples value는 `code`, `httpStatusCode`, `message` 세 항목
- 코드 `stberror.Errors.Data.InvalidRequest`, `stberror.Errors.Data.LimitExceeded`

## 검증

- `scalar document validate openapi.yml` 통과 (OpenAPI 3.0)
- `scalar document lint openapi.yml` 본 변경 범위에서 추가 issue 없음